### PR TITLE
feat(member): normalize Member.status replacing active

### DIFF
--- a/docs/openapi/church-members.yaml
+++ b/docs/openapi/church-members.yaml
@@ -13,7 +13,7 @@ paths:
   /api/v1/church/member:
     post:
       summary: Cria um membro
-      description: Registra um novo membro e dispara o job de criação de usuário.
+      description: Registra um novo membro e dispara o job de criação de usuário. Se o status não for informado, o padrão administrativo é APPROVED.
       tags: [ Church Members ]
       requestBody:
         required: true
@@ -43,7 +43,7 @@ paths:
                 $ref: '#/components/schemas/Member'
     put:
       summary: Atualiza um membro
-      description: Atualiza campos do membro; o único campo obrigatório é o `memberId`.
+      description: Atualiza campos do membro; o único campo obrigatório é o `memberId`. O status pode ser APPROVED ou INACTIVE.
       tags: [ Church Members ]
       parameters:
         - $ref: '#/components/parameters/MemberId'
@@ -62,7 +62,8 @@ paths:
                 $ref: '#/components/schemas/MessageResponse'
   /api/v1/church/member/list:
     get:
-      summary: Lista membros (paginado)
+      summary: Lista membros administrativos (paginado)
+      description: Retorna membros com status APPROVED ou INACTIVE para gestão administrativa. Não inclui PENDING_REVIEW.
       tags: [ Church Members ]
       parameters:
         - in: query
@@ -109,7 +110,8 @@ paths:
                 required: [ count, results ]
   /api/v1/church/member/all:
     get:
-      summary: Lista todos os membros por igreja
+      summary: Lista todos os membros operacionais por igreja
+      description: Retorna apenas membros com status APPROVED. Usado para alimentar selects operativos (contas a receber, centros de custo, patrimônio).
       tags: [ Church Members ]
       responses:
         '200':
@@ -166,6 +168,16 @@ components:
         - notifyChurchEvents
         - notifyStatusContributions
         - lang
+    MemberStatus:
+      type: string
+      enum:
+        - PENDING_REVIEW
+        - APPROVED
+        - INACTIVE
+      description: |
+        PENDING_REVIEW: registrado, pendente de aprovação.
+        APPROVED: aprovado e operacionalmente ativo.
+        INACTIVE: aprovado previamente, atualmente inativo.
     Member:
       type: object
       properties:
@@ -206,8 +218,8 @@ components:
           type: boolean
         settings:
           $ref: '#/components/schemas/MemberSettings'
-        active:
-          type: boolean
+        status:
+          $ref: '#/components/schemas/MemberStatus'
       required:
         - memberId
         - church
@@ -221,7 +233,7 @@ components:
         - isMinister
         - isTreasurer
         - settings
-        - active
+        - status
     CreateMemberPayload:
       type: object
       properties:
@@ -248,8 +260,9 @@ components:
         birthdate:
           type: string
           example: '2000-01-01'
-        active:
-          type: boolean
+        status:
+          $ref: '#/components/schemas/MemberStatus'
+          description: Opcional. Se não informado, assume APPROVED. Administrativo aceita apenas APPROVED ou INACTIVE.
         settings:
           $ref: '#/components/schemas/MemberSettings'
       required:
@@ -261,7 +274,6 @@ components:
         - isTreasurer
         - churchId
         - birthdate
-        - active
     UpdateMemberPayload:
       type: object
       properties:
@@ -286,8 +298,8 @@ components:
         birthdate:
           type: string
           example: '2000-01-01'
-        active:
-          type: boolean
+        status:
+          $ref: '#/components/schemas/MemberStatus'
+          description: Opcional. Administrativo aceita apenas APPROVED ou INACTIVE.
         settings:
           $ref: '#/components/schemas/MemberSettings'
-

--- a/docs/openapi/church-members.yaml
+++ b/docs/openapi/church-members.yaml
@@ -13,7 +13,7 @@ paths:
   /api/v1/church/member:
     post:
       summary: Cria um membro
-      description: Registra um novo membro e dispara o job de criação de usuário. Se o status não for informado, o padrão administrativo é APPROVED.
+      description: Registra um novo membro. Se o status não for informado, o padrão administrativo é APPROVED. Para membros APPROVED, dispara o job de criação de usuário; para INACTIVE, não dispara.
       tags: [ Church Members ]
       requestBody:
         required: true

--- a/migrate-mongo-config.cjs
+++ b/migrate-mongo-config.cjs
@@ -35,8 +35,8 @@ const config = {
   // if the file should be run.  Requires that scripts are coded to be run multiple times.
   useFileHash: false,
 
-  // Don't change this, unless you know what you're doing
-  moduleSystem: "esm",
+  // Aligned with existing migrations which all use CommonJS (module.exports).
+  moduleSystem: "commonjs",
 }
 
 module.exports = config

--- a/migrate-mongo-config.cjs
+++ b/migrate-mongo-config.cjs
@@ -35,8 +35,8 @@ const config = {
   // if the file should be run.  Requires that scripts are coded to be run multiple times.
   useFileHash: false,
 
-  // Aligned with existing migrations which all use CommonJS (module.exports).
-  moduleSystem: "commonjs",
+  // Don't change this, unless you know what you're doing
+  moduleSystem: "esm",
 }
 
 module.exports = config

--- a/migrations/20260601093100-normalize-member-status.js
+++ b/migrations/20260601093100-normalize-member-status.js
@@ -1,3 +1,5 @@
+const VALID_STATUSES = ["PENDING_REVIEW", "APPROVED", "INACTIVE"]
+
 module.exports = {
   /**
    * @param db {import('mongodb').Db}
@@ -7,39 +9,32 @@ module.exports = {
   async up(db, client) {
     const collection = db.collection("members")
 
-    // 1. active === false -> INACTIVE
+    // 1. active === false and status is missing or invalid -> INACTIVE
     await collection.updateMany(
-      { active: false },
+      { active: false, status: { $nin: VALID_STATUSES } },
       { $set: { status: "INACTIVE" }, $unset: { active: "" } }
     )
 
-    // 2. active === true -> APPROVED
+    // 2. active === true (or missing) and status is missing or invalid -> APPROVED
+    //    Covers active:true, active absent, or any active value other than false.
     await collection.updateMany(
-      { active: true },
+      { active: { $ne: false }, status: { $nin: VALID_STATUSES } },
       { $set: { status: "APPROVED" }, $unset: { active: "" } }
     )
 
-    // 3. Missing active and missing status -> APPROVED
-    //    Restricted to documents that also lack status so a retry does not
-    //    overwrite established INACTIVE or PENDING_REVIEW values.
+    // 3. Clean up active on documents that already have a valid status
     await collection.updateMany(
-      { active: { $exists: false }, status: { $exists: false } },
-      { $set: { status: "APPROVED" } }
+      { status: { $in: VALID_STATUSES }, active: { $exists: true } },
+      { $unset: { active: "" } }
     )
 
-    // 4. Ensure no documents lack status (final idempotency guard)
+    // 4. Final guard: any document still lacking status -> APPROVED
     await collection.updateMany(
       { status: { $exists: false } },
       { $set: { status: "APPROVED" } }
     )
 
-    // 5. Remove active from all documents (idempotency)
-    await collection.updateMany(
-      { active: { $exists: true } },
-      { $unset: { active: "" } }
-    )
-
-    // 6. Create named index
+    // 5. Create named index
     const indexes = await collection.indexes()
     const hasIndex = indexes.some(
       (idx) => idx.name === "idx_members_church_status_created"
@@ -51,11 +46,11 @@ module.exports = {
       )
     }
 
-    // 7. Backfill embedded contribution member snapshots
+    // 6. Backfill embedded contribution member snapshots (additive only)
     //    Old OnlineContributions.toPrimitives() emitted the full Member aggregate
     //    with nested member.church.{churchId,name}. The new ContributionMemberSnapshot
-    //    expects flat member.{churchId,churchName}. Migrate old snapshots idempotently
-    //    so that UpdateContributionStatus does not pass undefined as churchId.
+    //    expects flat member.{churchId,churchName}. Add the flat fields idempotently
+    //    without removing historical fields so rollback remains safe.
     const contributions = db.collection("contributions")
     await contributions.updateMany(
       {
@@ -68,23 +63,6 @@ module.exports = {
             "member.churchId": "$member.church.churchId",
             "member.churchName": { $ifNull: ["$member.church.name", ""] },
           },
-        },
-        {
-          $unset: [
-            "member.church",
-            "member.email",
-            "member.phone",
-            "member.createdAt",
-            "member.dni",
-            "member.conversionDate",
-            "member.baptismDate",
-            "member.birthdate",
-            "member.isMinister",
-            "member.isTreasurer",
-            "member.settings",
-            "member.active",
-            "member.status",
-          ],
         },
       ]
     )

--- a/migrations/20260601093100-normalize-member-status.js
+++ b/migrations/20260601093100-normalize-member-status.js
@@ -1,0 +1,74 @@
+module.exports = {
+  /**
+   * @param db {import('mongodb').Db}
+   * @param client {import('mongodb').MongoClient}
+   * @returns {Promise<void>}
+   */
+  async up(db, client) {
+    const collection = db.collection("members")
+
+    // 1. Migrate existing active field to status
+    await collection.updateMany(
+      { active: false },
+      { $set: { status: "INACTIVE" }, $unset: { active: "" } }
+    )
+
+    await collection.updateMany(
+      { $or: [{ active: true }, { active: { $exists: false } }] },
+      { $set: { status: "APPROVED" }, $unset: { active: "" } }
+    )
+
+    // 2. Ensure no documents lack status (idempotency guard)
+    await collection.updateMany(
+      { status: { $exists: false } },
+      { $set: { status: "APPROVED" } }
+    )
+
+    // 3. Remove active from all documents (idempotency)
+    await collection.updateMany(
+      { active: { $exists: true } },
+      { $unset: { active: "" } }
+    )
+
+    // 4. Create named index
+    const indexes = await collection.indexes()
+    const hasIndex = indexes.some(
+      (idx) => idx.name === "idx_members_church_status_created"
+    )
+    if (!hasIndex) {
+      await collection.createIndex(
+        { "church.churchId": 1, status: 1, createdAt: -1 },
+        { name: "idx_members_church_status_created", background: true }
+      )
+    }
+  },
+
+  /**
+   * @param db {import('mongodb').Db}
+   * @param client {import('mongodb').MongoClient}
+   * @returns {Promise<void>}
+   */
+  async down(db, client) {
+    const collection = db.collection("members")
+
+    // Rollback: APPROVED -> active: true; INACTIVE/PENDING_REVIEW -> active: false
+    await collection.updateMany(
+      { status: "APPROVED" },
+      { $set: { active: true }, $unset: { status: "" } }
+    )
+
+    await collection.updateMany(
+      { status: { $in: ["INACTIVE", "PENDING_REVIEW"] } },
+      { $set: { active: false }, $unset: { status: "" } }
+    )
+
+    // Drop named index
+    const indexes = await collection.indexes()
+    const hasIndex = indexes.some(
+      (idx) => idx.name === "idx_members_church_status_created"
+    )
+    if (hasIndex) {
+      await collection.dropIndex("idx_members_church_status_created")
+    }
+  },
+}

--- a/migrations/20260601093100-normalize-member-status.js
+++ b/migrations/20260601093100-normalize-member-status.js
@@ -7,30 +7,39 @@ module.exports = {
   async up(db, client) {
     const collection = db.collection("members")
 
-    // 1. Migrate existing active field to status
+    // 1. active === false -> INACTIVE
     await collection.updateMany(
       { active: false },
       { $set: { status: "INACTIVE" }, $unset: { active: "" } }
     )
 
+    // 2. active === true -> APPROVED
     await collection.updateMany(
-      { $or: [{ active: true }, { active: { $exists: false } }] },
+      { active: true },
       { $set: { status: "APPROVED" }, $unset: { active: "" } }
     )
 
-    // 2. Ensure no documents lack status (idempotency guard)
+    // 3. Missing active and missing status -> APPROVED
+    //    Restricted to documents that also lack status so a retry does not
+    //    overwrite established INACTIVE or PENDING_REVIEW values.
+    await collection.updateMany(
+      { active: { $exists: false }, status: { $exists: false } },
+      { $set: { status: "APPROVED" } }
+    )
+
+    // 4. Ensure no documents lack status (final idempotency guard)
     await collection.updateMany(
       { status: { $exists: false } },
       { $set: { status: "APPROVED" } }
     )
 
-    // 3. Remove active from all documents (idempotency)
+    // 5. Remove active from all documents (idempotency)
     await collection.updateMany(
       { active: { $exists: true } },
       { $unset: { active: "" } }
     )
 
-    // 4. Create named index
+    // 6. Create named index
     const indexes = await collection.indexes()
     const hasIndex = indexes.some(
       (idx) => idx.name === "idx_members_church_status_created"

--- a/migrations/20260601093100-normalize-member-status.js
+++ b/migrations/20260601093100-normalize-member-status.js
@@ -50,6 +50,44 @@ module.exports = {
         { name: "idx_members_church_status_created", background: true }
       )
     }
+
+    // 7. Backfill embedded contribution member snapshots
+    //    Old OnlineContributions.toPrimitives() emitted the full Member aggregate
+    //    with nested member.church.{churchId,name}. The new ContributionMemberSnapshot
+    //    expects flat member.{churchId,churchName}. Migrate old snapshots idempotently
+    //    so that UpdateContributionStatus does not pass undefined as churchId.
+    const contributions = db.collection("contributions")
+    await contributions.updateMany(
+      {
+        "member.church.churchId": { $exists: true },
+        "member.churchId": { $exists: false },
+      },
+      [
+        {
+          $set: {
+            "member.churchId": "$member.church.churchId",
+            "member.churchName": { $ifNull: ["$member.church.name", ""] },
+          },
+        },
+        {
+          $unset: [
+            "member.church",
+            "member.email",
+            "member.phone",
+            "member.createdAt",
+            "member.dni",
+            "member.conversionDate",
+            "member.baptismDate",
+            "member.birthdate",
+            "member.isMinister",
+            "member.isTreasurer",
+            "member.settings",
+            "member.active",
+            "member.status",
+          ],
+        },
+      ]
+    )
   },
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "church_financial_api",
-  "version": "2.12.0",
+  "version": "2.12.3",
   "description": "API Church Financial System",
   "main": "dist/app.js",
   "scripts": {
@@ -8,7 +8,7 @@
     "test": "bunx jest --forceExit --runInBand --detectOpenHandles",
     "start:prod": "bun src/app.ts",
     "cli": "bun src/cli.ts",
-    "migrate": "set -a && . ./.env && set +a && migrate-mongo up",
+    "migrate": "set -a && . ./.env && set +a && ts-mongo migrate:up",
     "format": "prettier --write \"src/**/*.{ts,hbs}\" ",
     "format:check": "prettier --check \"src/**/*.ts\"",
     "copy-static-assets": "bun src/copyStaticAssets.ts"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "bunx jest --forceExit --runInBand --detectOpenHandles",
     "start:prod": "bun src/app.ts",
     "cli": "bun src/cli.ts",
-    "migrate": "set -a && . ./.env && set +a && ts-mongo migrate:up",
+    "migrate": "set -a && . ./.env && set +a && migrate-mongo up",
     "format": "prettier --write \"src/**/*.{ts,hbs}\" ",
     "format:check": "prettier --check \"src/**/*.ts\"",
     "copy-static-assets": "bun src/copyStaticAssets.ts"

--- a/scripts/migrate-queue-member-status.ts
+++ b/scripts/migrate-queue-member-status.ts
@@ -1,0 +1,76 @@
+/**
+ * Queue payload migration: CreateUserForMemberJob
+ *
+ * Run BEFORE deploying the new Member.status contract if the queue may contain
+ * jobs dispatched by the previous version (which carried `active` instead of
+ * `status`). Waiting / delayed jobs with `active` but no `status` are
+ * rewritten so the new CreateUserForMemberJob.handle() can hydrate them
+ * without throwing InvalidMemberStatus.
+ *
+ * Usage (from repo root):
+ *   bun scripts/migrate-queue-member-status.ts
+ *
+ * The script is idempotent: re-running it skips already-migrated jobs.
+ */
+
+import { Queue } from "bullmq"
+import { readRedisConnectionOptions } from "../src/Shared/helpers/ReadRedisConnectionOptions.helper"
+
+const QUEUE_NAME = "CreateUserForMemberJob"
+
+const main = async (): Promise<void> => {
+  const redisOpts = readRedisConnectionOptions()
+  const queue = new Queue(QUEUE_NAME, {
+    connection: redisOpts,
+  })
+
+  let migrated = 0
+  let skipped = 0
+  let errors = 0
+
+  const states: Array<"waiting" | "delayed" | "paused"> = [
+    "waiting",
+    "delayed",
+    "paused",
+  ]
+
+  for (const state of states) {
+    const jobs = await queue.getJobs(state, 0, -1)
+
+    for (const job of jobs) {
+      const data = job.data as any
+
+      // Already migrated or never had the old shape
+      if (data.status || data.active === undefined) {
+        skipped++
+        continue
+      }
+
+      const updated = {
+        ...data,
+        status: data.active === true ? "APPROVED" : "INACTIVE",
+      }
+      delete updated.active
+
+      try {
+        await job.updateData(updated)
+        migrated++
+      } catch (err) {
+        console.error(`Failed to update job ${job.id}:`, err)
+        errors++
+      }
+    }
+  }
+
+  console.log(
+    `[${QUEUE_NAME}] migrated=${migrated} skipped=${skipped} errors=${errors}`
+  )
+
+  await queue.close()
+  process.exit(0)
+}
+
+void main().catch((err) => {
+  console.error("Migration failed:", err)
+  process.exit(1)
+})

--- a/src/Church/applications/devotional/services/DevotionalDeliveryService.ts
+++ b/src/Church/applications/devotional/services/DevotionalDeliveryService.ts
@@ -403,7 +403,9 @@ export class DevotionalDeliveryService {
     audience: DevotionalAudience
   ) {
     this.logger.info(`Resolving audience`)
-    const members = await this.memberRepository.all(churchId, { status: "APPROVED" })
+    const members = await this.memberRepository.all(churchId, {
+      status: "APPROVED",
+    })
 
     if (audience === DevotionalAudience.ALL) {
       return members

--- a/src/Church/applications/devotional/services/DevotionalDeliveryService.ts
+++ b/src/Church/applications/devotional/services/DevotionalDeliveryService.ts
@@ -96,7 +96,7 @@ export class DevotionalDeliveryService {
     this.logger.info(`notify the pastor to review the devotional`)
 
     const pastor = await this.memberRepository.one({
-      churchId: church.getChurchId(),
+      "church.churchId": church.getChurchId(),
       status: "APPROVED",
       isMinister: true,
     })

--- a/src/Church/applications/devotional/services/DevotionalDeliveryService.ts
+++ b/src/Church/applications/devotional/services/DevotionalDeliveryService.ts
@@ -97,7 +97,7 @@ export class DevotionalDeliveryService {
 
     const pastor = await this.memberRepository.one({
       churchId: church.getChurchId(),
-      active: true,
+      status: "APPROVED",
       isMinister: true,
     })
 
@@ -403,7 +403,7 @@ export class DevotionalDeliveryService {
     audience: DevotionalAudience
   ) {
     this.logger.info(`Resolving audience`)
-    const members = await this.memberRepository.all(churchId, { active: true })
+    const members = await this.memberRepository.all(churchId, { status: "APPROVED" })
 
     if (audience === DevotionalAudience.ALL) {
       return members
@@ -423,7 +423,7 @@ export class DevotionalDeliveryService {
     }
 
     // Gender is not explicitly modeled in current Member aggregate.
-    // Until that profile data is available, fallback to all active members.
+    // Until that profile data is available, fallback to all approved members.
     return members
   }
 

--- a/src/Church/applications/members/AllMember.ts
+++ b/src/Church/applications/members/AllMember.ts
@@ -1,4 +1,4 @@
-import { IMemberRepository } from "@/Church/domain"
+import { IMemberRepository, MemberStatus } from "@/Church/domain"
 import { Logger } from "@/Shared/adapter"
 
 export class AllMember {
@@ -9,6 +9,8 @@ export class AllMember {
   async execute(churchId: string): Promise<any> {
     this.logger.info(`search all members churchId ${churchId}`)
 
-    return await this.memberRepository.all(churchId)
+    return await this.memberRepository.all(churchId, {
+      status: MemberStatus.APPROVED,
+    })
   }
 }

--- a/src/Church/applications/members/CreateMember.ts
+++ b/src/Church/applications/members/CreateMember.ts
@@ -46,11 +46,16 @@ export class CreateMember {
 
     await this.memberRepository.upsert(member)
 
-    this.queueService.dispatch(QueueName.CreateUserForMemberJob, member)
-
-    this.logger.info(
-      `Queue dispatched for create user for member ${JSON.stringify(member)}`
-    )
+    if (member.getStatus() === MemberStatus.INACTIVE) {
+      this.logger.info(
+        `Member ${member.getMemberId()} created as INACTIVE; skipping user creation job`
+      )
+    } else {
+      this.queueService.dispatch(QueueName.CreateUserForMemberJob, member)
+      this.logger.info(
+        `Queue dispatched for create user for member ${member.getMemberId()}`
+      )
+    }
   }
 
   private async getChurch(churchId: string): Promise<Church> {

--- a/src/Church/applications/members/CreateMember.ts
+++ b/src/Church/applications/members/CreateMember.ts
@@ -1,7 +1,8 @@
-import type {
-  CreateMemberRequest,
-  IChurchRepository,
-  IMemberRepository,
+import {
+  type CreateMemberRequest,
+  type IChurchRepository,
+  type IMemberRepository,
+  MemberStatus,
 } from "../../domain"
 import { Church, ChurchNotFound, Member, MemberExist } from "../../domain"
 import { Logger } from "@/Shared/adapter"
@@ -38,9 +39,10 @@ export class CreateMember {
       settings: request.settings,
     })
 
-    if (!request.active) {
-      member.disable()
+    if (request.status === MemberStatus.INACTIVE) {
+      member.inactivate()
     }
+    // else: Member.create defaults to APPROVED; PENDING_REVIEW is not accepted via admin POST
 
     await this.memberRepository.upsert(member)
 

--- a/src/Church/applications/members/SearchMembers.ts
+++ b/src/Church/applications/members/SearchMembers.ts
@@ -1,5 +1,5 @@
-import { IMemberRepository } from "../../domain"
-import { MemberPaginateRequest } from "@/Church/domain"
+import { type IMemberRepository, MemberStatus } from "../../domain"
+import { type MemberPaginateRequest } from "@/Church/domain"
 import {
   Criteria,
   Filters,
@@ -43,6 +43,14 @@ export class SearchMembers {
         ])
       )
     }
+
+    filters.push(
+      new Map([
+        ["field", "status"],
+        ["operator", Operator.IN],
+        ["value", [MemberStatus.APPROVED, MemberStatus.INACTIVE]],
+      ])
+    )
 
     return new Criteria(
       Filters.fromValues(filters),

--- a/src/Church/applications/members/UpdateMember.ts
+++ b/src/Church/applications/members/UpdateMember.ts
@@ -2,6 +2,7 @@ import {
   IMemberRepository,
   Member,
   MemberNotFound,
+  MemberStatus,
   UpdateMemberRequest,
 } from "../../domain"
 import { Logger } from "@/Shared/adapter"
@@ -35,9 +36,12 @@ export class UpdateMember {
       member.isTreasurer = request.isTreasurer
     }
 
-    if (typeof request.active === "boolean") {
-      if (request.active) member.enable()
-      else member.disable()
+    if (request.status) {
+      if (request.status === MemberStatus.APPROVED) {
+        member.approve()
+      } else if (request.status === MemberStatus.INACTIVE) {
+        member.inactivate()
+      }
     }
 
     if (request.settings) {

--- a/src/Church/applications/members/UpdateMember.ts
+++ b/src/Church/applications/members/UpdateMember.ts
@@ -1,5 +1,6 @@
 import {
   IMemberRepository,
+  InvalidMemberStatus,
   Member,
   MemberNotFound,
   MemberStatus,
@@ -41,6 +42,8 @@ export class UpdateMember {
         member.approve()
       } else if (request.status === MemberStatus.INACTIVE) {
         member.inactivate()
+      } else if (request.status === MemberStatus.PENDING_REVIEW) {
+        throw new InvalidMemberStatus()
       }
     }
 

--- a/src/Church/domain/Member.ts
+++ b/src/Church/domain/Member.ts
@@ -103,7 +103,10 @@ export class Member extends AggregateRoot {
 
     m.id = plainData.id
 
-    if (!plainData.status || !Object.values(MemberStatus).includes(plainData.status)) {
+    if (
+      !plainData.status ||
+      !Object.values(MemberStatus).includes(plainData.status)
+    ) {
       throw new InvalidMemberStatus()
     }
     m.status = plainData.status as MemberStatus

--- a/src/Church/domain/Member.ts
+++ b/src/Church/domain/Member.ts
@@ -3,6 +3,8 @@ import { Church } from "./Church"
 import { DateBR } from "@/Shared/helpers"
 import { AggregateRoot } from "@abejarano/ts-mongodb-criteria"
 import { MemberSettings } from "@/Church/domain"
+import { MemberStatus } from "./enums/MemberStatus.enum"
+import { InvalidMemberStatus } from "./exceptions/InvalidMemberStatus.exception"
 
 export class Member extends AggregateRoot {
   public isTreasurer: boolean
@@ -21,7 +23,7 @@ export class Member extends AggregateRoot {
     churchId: string
     name: string
   }
-  private active: boolean
+  private status: MemberStatus
   private settings: MemberSettings
 
   static create(params: {
@@ -66,7 +68,7 @@ export class Member extends AggregateRoot {
     m.memberId = IdentifyEntity.get(`member`)
     m.isTreasurer = isTreasurer
     m.isMinister = isMinister
-    m.active = true
+    m.status = MemberStatus.APPROVED
 
     if (!settings) {
       m.settings = {
@@ -100,7 +102,12 @@ export class Member extends AggregateRoot {
     m.church = plainData.church
 
     m.id = plainData.id
-    m.active = plainData.active
+
+    if (!plainData.status || !Object.values(MemberStatus).includes(plainData.status)) {
+      throw new InvalidMemberStatus()
+    }
+    m.status = plainData.status as MemberStatus
+
     m.settings = plainData.settings
       ? plainData.settings
       : {
@@ -174,12 +181,24 @@ export class Member extends AggregateRoot {
     this.name = name
   }
 
-  disable() {
-    this.active = false
+  getStatus(): MemberStatus {
+    return this.status
   }
 
-  enable() {
-    this.active = true
+  setStatus(status: MemberStatus) {
+    this.status = status
+  }
+
+  approve() {
+    this.status = MemberStatus.APPROVED
+  }
+
+  markAsPendingReview() {
+    this.status = MemberStatus.PENDING_REVIEW
+  }
+
+  inactivate() {
+    this.status = MemberStatus.INACTIVE
   }
 
   getSettings() {
@@ -205,7 +224,7 @@ export class Member extends AggregateRoot {
       isMinister: this.isMinister,
       isTreasurer: this.isTreasurer,
       settings: this.settings,
-      active: this.active,
+      status: this.status,
     }
   }
 }

--- a/src/Church/domain/enums/MemberStatus.enum.ts
+++ b/src/Church/domain/enums/MemberStatus.enum.ts
@@ -1,0 +1,7 @@
+export enum MemberStatus {
+  PENDING_REVIEW = "PENDING_REVIEW",
+  APPROVED = "APPROVED",
+  INACTIVE = "INACTIVE",
+}
+
+export const MEMBER_STATUS_VALUES = Object.values(MemberStatus)

--- a/src/Church/domain/exceptions/InvalidMemberStatus.exception.ts
+++ b/src/Church/domain/exceptions/InvalidMemberStatus.exception.ts
@@ -1,0 +1,6 @@
+import { DomainException } from "@/Shared/domain"
+
+export class InvalidMemberStatus extends DomainException {
+  name = "INVALID_MEMBER_STATUS"
+  message = "The member status is invalid or missing"
+}

--- a/src/Church/domain/index.ts
+++ b/src/Church/domain/index.ts
@@ -20,6 +20,7 @@ export type { IDevotionalCommentRepository } from "./interfaces/DevotionalCommen
 export { ChurchNotFound } from "./exceptions/ChurchNotFound.exception"
 export { MemberNotFound } from "./exceptions/MemberNotFound.exception"
 export { MemberExist } from "./exceptions/MemberExist.exception"
+export { InvalidMemberStatus } from "./exceptions/InvalidMemberStatus.exception"
 export { MinisterNotFound } from "./exceptions/MinisterNotFound.exception"
 export { WhatsappCredentialAlreadyAssigned } from "./exceptions/WhatsappCredentialAlreadyAssigned.exception"
 export { WhatsappCredentialsNotConfigured } from "./exceptions/WhatsappCredentialsNotConfigured.exception"
@@ -47,6 +48,7 @@ export type { CreateDevotionalCommentRequest } from "./requests/CreateDevotional
 export type { UpdateDevotionalCommentRequest } from "./requests/UpdateDevotionalComment.request"
 
 export { ChurchStatus } from "./enums/ChurchStatus.enum"
+export { MemberStatus } from "./enums/MemberStatus.enum"
 export { MinisterType } from "./enums/MinisterType.enum"
 export {
   DevotionalAudience,

--- a/src/Church/domain/requests/CreateMember.request.ts
+++ b/src/Church/domain/requests/CreateMember.request.ts
@@ -1,4 +1,5 @@
 import { MemberSettings } from "@/Church/domain"
+import { MemberStatus } from "../enums/MemberStatus.enum"
 
 export type CreateMemberRequest = {
   name: string
@@ -10,6 +11,6 @@ export type CreateMemberRequest = {
   isTreasurer: boolean
   churchId: string
   birthdate: Date
-  active: boolean
+  status?: MemberStatus
   settings?: MemberSettings
 }

--- a/src/Church/domain/requests/UpdateMember.request.ts
+++ b/src/Church/domain/requests/UpdateMember.request.ts
@@ -1,4 +1,5 @@
 import { MemberSettings } from "@/Church/domain"
+import { MemberStatus } from "../enums/MemberStatus.enum"
 
 export type UpdateMemberRequest = {
   memberId: string
@@ -10,6 +11,6 @@ export type UpdateMemberRequest = {
   baptismDate?: Date
   isTreasurer?: boolean
   birthdate?: Date
-  active?: boolean
+  status?: MemberStatus
   settings?: MemberSettings
 }

--- a/src/Church/infrastructure/http/validators/CreateMember.validator.ts
+++ b/src/Church/infrastructure/http/validators/CreateMember.validator.ts
@@ -24,7 +24,7 @@ export const CreateMemberValidator = async (
     isTreasurer: "required|boolean",
     churchId: "required",
     birthdate: "required|dateFormat:YYYY-MM-DD",
-    active: "required|boolean",
+    status: "sometimes|in:APPROVED,INACTIVE",
   }
 
   const v = new Validator(payload, rules)

--- a/src/Church/infrastructure/http/validators/UpdateMember.validator.ts
+++ b/src/Church/infrastructure/http/validators/UpdateMember.validator.ts
@@ -26,7 +26,7 @@ export const UpdateMemberValidator = async (
     baptismDate: "sometimes|dateFormat:YYYY-MM-DD",
     birthdate: "sometimes|dateFormat:YYYY-MM-DD",
     isTreasurer: "sometimes|boolean",
-    active: "sometimes|boolean",
+    status: "sometimes|in:APPROVED,INACTIVE",
   }
 
   const v = new Validator(payload, rules)

--- a/src/Church/infrastructure/persistence/MemberMongoRepository.ts
+++ b/src/Church/infrastructure/persistence/MemberMongoRepository.ts
@@ -70,5 +70,9 @@ export class MemberMongoRepository
     await collection.createIndex({ "church.churchId": 1 })
     await collection.createIndex({ memberId: 1 })
     await collection.createIndex({ dni: 1 }, { unique: true })
+    await collection.createIndex(
+      { "church.churchId": 1, status: 1, createdAt: -1 },
+      { name: "idx_members_church_status_created", background: true }
+    )
   }
 }

--- a/src/Financial/applications/contribution/UpdateContributionStatus.ts
+++ b/src/Financial/applications/contribution/UpdateContributionStatus.ts
@@ -93,7 +93,7 @@ export class UpdateContributionStatus {
         availabilityAccountId: contribution
           .getAvailabilityAccount()
           .getAvailabilityAccountId(),
-        churchId: contribution.getMember().getChurch().churchId,
+        churchId: contribution.getMember().getChurchId(),
         amount: AmountValue.create(contribution.getAmount()),
         voucher: contribution.getBankTransferReceipt(),
         concept: concept.getName(),

--- a/src/Financial/domain/ContributionMemberSnapshot.ts
+++ b/src/Financial/domain/ContributionMemberSnapshot.ts
@@ -1,0 +1,54 @@
+export class ContributionMemberSnapshot {
+  private memberId: string
+  private name: string
+  private churchId: string
+  private churchName: string
+
+  static fromMember(member: {
+    getMemberId(): string
+    getName(): string
+    getChurch(): { churchId: string; name: string }
+  }): ContributionMemberSnapshot {
+    const snapshot = new ContributionMemberSnapshot()
+    snapshot.memberId = member.getMemberId()
+    snapshot.name = member.getName()
+    const church = member.getChurch()
+    snapshot.churchId = church.churchId
+    snapshot.churchName = church.name
+    return snapshot
+  }
+
+  static fromPrimitives(plainData: any): ContributionMemberSnapshot {
+    const snapshot = new ContributionMemberSnapshot()
+    snapshot.memberId = plainData.memberId
+    snapshot.name = plainData.name
+    snapshot.churchId = plainData.churchId
+    snapshot.churchName = plainData.churchName
+    return snapshot
+  }
+
+  getMemberId(): string {
+    return this.memberId
+  }
+
+  getName(): string {
+    return this.name
+  }
+
+  getChurchId(): string {
+    return this.churchId
+  }
+
+  getChurchName(): string {
+    return this.churchName
+  }
+
+  toPrimitives(): any {
+    return {
+      memberId: this.memberId,
+      name: this.name,
+      churchId: this.churchId,
+      churchName: this.churchName,
+    }
+  }
+}

--- a/src/Financial/domain/ContributionMemberSnapshot.ts
+++ b/src/Financial/domain/ContributionMemberSnapshot.ts
@@ -19,11 +19,16 @@ export class ContributionMemberSnapshot {
   }
 
   static fromPrimitives(plainData: any): ContributionMemberSnapshot {
+    if (!plainData.memberId || !plainData.name || !plainData.churchId) {
+      throw new Error(
+        `ContributionMemberSnapshot.fromPrimitives missing required fields: got memberId=${plainData.memberId}, name=${plainData.name}, churchId=${plainData.churchId}`
+      )
+    }
     const snapshot = new ContributionMemberSnapshot()
     snapshot.memberId = plainData.memberId
     snapshot.name = plainData.name
     snapshot.churchId = plainData.churchId
-    snapshot.churchName = plainData.churchName
+    snapshot.churchName = plainData.churchName ?? ""
     return snapshot
   }
 

--- a/src/Financial/domain/OnlineContributions.ts
+++ b/src/Financial/domain/OnlineContributions.ts
@@ -67,7 +67,9 @@ export class OnlineContributions extends AggregateRoot {
   static override fromPrimitives(plainData: any): OnlineContributions {
     const contributions: OnlineContributions = new OnlineContributions()
     contributions.id = plainData.id
-    contributions.member = ContributionMemberSnapshot.fromPrimitives(plainData.member)
+    contributions.member = ContributionMemberSnapshot.fromPrimitives(
+      plainData.member
+    )
     contributions.contributionId = plainData.contributionId
     contributions.status = plainData.status
     contributions.amount = plainData.amount

--- a/src/Financial/domain/OnlineContributions.ts
+++ b/src/Financial/domain/OnlineContributions.ts
@@ -1,16 +1,16 @@
 import { OnlineContributionsStatus } from "./enums/OnlineContributionsStatus.enum"
 import { IdentifyEntity } from "@/Shared/adapter"
-import { Member } from "@/Church/domain"
 import { AvailabilityAccount, FinancialConcept } from "@/FinanceConfig/domain"
 import { FinancialConceptDisable } from "./exceptions/FinancialConceptDisable.exception"
 import { DateBR } from "@/Shared/helpers"
 import { AggregateRoot } from "@abejarano/ts-mongodb-criteria"
 import { AmountValue } from "@/Shared/domain"
+import { ContributionMemberSnapshot } from "./ContributionMemberSnapshot"
 
 export class OnlineContributions extends AggregateRoot {
   private id?: string
   private churchId: string
-  private member: Member
+  private member: ContributionMemberSnapshot
   private contributionId: string
   private status: OnlineContributionsStatus
   private financialConcept: FinancialConcept
@@ -25,7 +25,11 @@ export class OnlineContributions extends AggregateRoot {
 
   static create(
     amount: AmountValue,
-    member: Member,
+    member: {
+      getMemberId(): string
+      getName(): string
+      getChurch(): { churchId: string; name: string }
+    },
     financialConcept: FinancialConcept,
     bankTransferReceipt: string,
     observation: string = "",
@@ -37,7 +41,7 @@ export class OnlineContributions extends AggregateRoot {
     }
   ): OnlineContributions {
     const contributions: OnlineContributions = new OnlineContributions()
-    contributions.member = member
+    contributions.member = ContributionMemberSnapshot.fromMember(member)
     contributions.churchId = member.getChurch().churchId
     contributions.contributionId = IdentifyEntity.get(`contribution`)
     contributions.bankTransferReceipt = bankTransferReceipt
@@ -63,7 +67,7 @@ export class OnlineContributions extends AggregateRoot {
   static override fromPrimitives(plainData: any): OnlineContributions {
     const contributions: OnlineContributions = new OnlineContributions()
     contributions.id = plainData.id
-    contributions.member = Member.fromPrimitives(plainData.member)
+    contributions.member = ContributionMemberSnapshot.fromPrimitives(plainData.member)
     contributions.contributionId = plainData.contributionId
     contributions.status = plainData.status
     contributions.amount = plainData.amount
@@ -108,7 +112,7 @@ export class OnlineContributions extends AggregateRoot {
     return this.createdAt
   }
 
-  getMember(): Member {
+  getMember(): ContributionMemberSnapshot {
     return this.member
   }
 
@@ -139,7 +143,7 @@ export class OnlineContributions extends AggregateRoot {
   toPrimitives() {
     return {
       contributionId: this.contributionId,
-      member: this.member,
+      member: this.member.toPrimitives(),
       status: this.status,
       amount: this.amount,
       createdAt: this.createdAt,

--- a/src/PushNotifications/infrastructure/NotifyFCM.job.ts
+++ b/src/PushNotifications/infrastructure/NotifyFCM.job.ts
@@ -73,7 +73,7 @@ export class NotifyFCMJob implements IJob {
 
   private async notifyAllMembers(args: NotificationRequest): Promise<void> {
     const members = await this.memberRepository.all(args.churchId, {
-      active: true,
+      status: "APPROVED",
     })
 
     await this.notifyMembers({ ...args, members })

--- a/test/Church/applications/CreateMember.spec.ts
+++ b/test/Church/applications/CreateMember.spec.ts
@@ -103,7 +103,7 @@ describe("CreateMember", () => {
     )
   })
 
-  it("creates member with INACTIVE status", async () => {
+  it("creates member with INACTIVE status and skips user creation job", async () => {
     memberRepository.one.mockResolvedValue(null as any)
     churchRepository.one.mockResolvedValue(createChurch())
 
@@ -118,10 +118,20 @@ describe("CreateMember", () => {
     const member = memberRepository.upsert.mock.calls[0]![0]
     expect(member.toPrimitives().status).toBe(MemberStatus.INACTIVE)
 
-    // TODO: future PENDING_REVIEW flow must NOT dispatch CreateUserForMemberJob before approval
-    expect(queueService.dispatch).toHaveBeenCalledWith(
-      QueueName.CreateUserForMemberJob,
-      member
+    expect(queueService.dispatch).not.toHaveBeenCalled()
+  })
+
+  it("does not dispatch user job for INACTIVE members", async () => {
+    memberRepository.one.mockResolvedValue(null as any)
+    churchRepository.one.mockResolvedValue(createChurch())
+
+    const useCase = new CreateMember(
+      memberRepository,
+      churchRepository,
+      queueService
     )
+    await useCase.execute(validRequest({ status: MemberStatus.INACTIVE }))
+
+    expect(queueService.dispatch).not.toHaveBeenCalled()
   })
 })

--- a/test/Church/applications/CreateMember.spec.ts
+++ b/test/Church/applications/CreateMember.spec.ts
@@ -6,6 +6,7 @@ import {
   IChurchRepository,
   IMemberRepository,
   MemberExist,
+  MemberStatus,
 } from "@/Church/domain"
 import { type IQueueService, QueueName } from "@/package/queue/domain"
 
@@ -40,7 +41,6 @@ const validRequest = (
   isTreasurer: false,
   churchId: "church-1",
   birthdate: new Date(),
-  active: true,
   ...overrides,
 })
 
@@ -82,21 +82,43 @@ describe("CreateMember", () => {
     )
   })
 
-  it("creates member, persists and dispatches queue", async () => {
-    memberRepository.one.mockResolvedValue(undefined)
-    churchRepository.findById.mockResolvedValue(createChurch())
+  it("creates member without status defaults to APPROVED and dispatches queue", async () => {
+    memberRepository.one.mockResolvedValue(null as any)
+    churchRepository.one.mockResolvedValue(createChurch())
 
     const useCase = new CreateMember(
       memberRepository,
       churchRepository,
       queueService
     )
-    await useCase.execute(validRequest({ active: false }))
+    await useCase.execute(validRequest())
 
     expect(memberRepository.upsert).toHaveBeenCalledTimes(1)
-    const member = memberRepository.upsert.mock.calls[0][0]
-    expect(member.toPrimitives().active).toBe(false)
+    const member = memberRepository.upsert.mock.calls[0]![0]
+    expect(member.toPrimitives().status).toBe(MemberStatus.APPROVED)
 
+    expect(queueService.dispatch).toHaveBeenCalledWith(
+      QueueName.CreateUserForMemberJob,
+      member
+    )
+  })
+
+  it("creates member with INACTIVE status", async () => {
+    memberRepository.one.mockResolvedValue(null as any)
+    churchRepository.one.mockResolvedValue(createChurch())
+
+    const useCase = new CreateMember(
+      memberRepository,
+      churchRepository,
+      queueService
+    )
+    await useCase.execute(validRequest({ status: MemberStatus.INACTIVE }))
+
+    expect(memberRepository.upsert).toHaveBeenCalledTimes(1)
+    const member = memberRepository.upsert.mock.calls[0]![0]
+    expect(member.toPrimitives().status).toBe(MemberStatus.INACTIVE)
+
+    // TODO: future PENDING_REVIEW flow must NOT dispatch CreateUserForMemberJob before approval
     expect(queueService.dispatch).toHaveBeenCalledWith(
       QueueName.CreateUserForMemberJob,
       member

--- a/test/Church/applications/UpdateMember.spec.ts
+++ b/test/Church/applications/UpdateMember.spec.ts
@@ -1,5 +1,5 @@
 import { UpdateMember } from "@/Church/applications"
-import { IMemberRepository, Member, MemberNotFound } from "@/Church/domain"
+import { IMemberRepository, Member, MemberNotFound, MemberStatus } from "@/Church/domain"
 
 const createMember = (): Member =>
   Member.fromPrimitives({
@@ -16,7 +16,7 @@ const createMember = (): Member =>
     isMinister: false,
     isTreasurer: false,
     church: { churchId: "church-1", name: "Church" },
-    active: true,
+    status: MemberStatus.APPROVED,
     settings: {
       notifyPaymentCommitments: true,
       notifyChurchEvents: true,
@@ -44,7 +44,7 @@ describe("UpdateMember", () => {
   })
 
   it("throws when member does not exist", async () => {
-    memberRepository.one.mockResolvedValue(undefined)
+    memberRepository.one.mockResolvedValue(null as any)
     const useCase = new UpdateMember(memberRepository)
 
     await expect(useCase.execute({ memberId: "member-1" })).rejects.toBeInstanceOf(
@@ -57,12 +57,12 @@ describe("UpdateMember", () => {
     memberRepository.one.mockResolvedValue(member)
 
     const useCase = new UpdateMember(memberRepository)
-    await useCase.execute({ memberId: "member-1", active: false, email: "NEW@X.com" })
+    await useCase.execute({ memberId: "member-1", status: MemberStatus.INACTIVE, email: "NEW@X.com" })
 
     expect(memberRepository.upsert).toHaveBeenCalledTimes(1)
-    const persisted = memberRepository.upsert.mock.calls[0][0]
+    const persisted = memberRepository.upsert.mock.calls[0]![0]
     const primitives = persisted.toPrimitives()
-    expect(primitives.active).toBe(false)
+    expect(primitives.status).toBe(MemberStatus.INACTIVE)
     expect(primitives.email).toBe("new@x.com")
   })
 })

--- a/test/Church/applications/UpdateMember.spec.ts
+++ b/test/Church/applications/UpdateMember.spec.ts
@@ -1,5 +1,5 @@
 import { UpdateMember } from "@/Church/applications"
-import { IMemberRepository, Member, MemberNotFound, MemberStatus } from "@/Church/domain"
+import { IMemberRepository, InvalidMemberStatus, Member, MemberNotFound, MemberStatus } from "@/Church/domain"
 
 const createMember = (): Member =>
   Member.fromPrimitives({
@@ -64,6 +64,16 @@ describe("UpdateMember", () => {
     const primitives = persisted.toPrimitives()
     expect(primitives.status).toBe(MemberStatus.INACTIVE)
     expect(primitives.email).toBe("new@x.com")
+  })
+
+  it("rejects PENDING_REVIEW status in administrative update", async () => {
+    const member = createMember()
+    memberRepository.one.mockResolvedValue(member)
+
+    const useCase = new UpdateMember(memberRepository)
+    await expect(
+      useCase.execute({ memberId: "member-1", status: MemberStatus.PENDING_REVIEW })
+    ).rejects.toBeInstanceOf(InvalidMemberStatus)
   })
 })
 


### PR DESCRIPTION
## Resumen
Reemplazar Member.active por Member.status como única fuente de verdad. Backend, OpenAPI y migración se entregan coordinadamente, sin aliases, coerciones ni fallbacks silenciosos.

## Estados válidos
- PENDING_REVIEW: registrado, pendiente de aprobación.
- APPROVED: aprobado y operacionalmente activo.
- INACTIVE: aprobado previamente, actualmente inactivo.

## Cambios principales
### Dominio
- Crear MemberStatus.enum.ts e InvalidMemberStatus.exception.
- Eliminar active, enable(), disable() de Member.
- Incorporar status, approve(), markAsPendingReview(), inactivate(), getStatus(), setStatus().
- fromPrimitives() exige status válido; toPrimitives() emite status y nunca active.

### Application / HTTP
- POST: status opcional; sin valor default explícito a APPROVED. Si llega, solo APPROVED o INACTIVE.
- PUT: status opcional; solo APPROVED o INACTIVE.
- /list: filtra status IN [APPROVED, INACTIVE].
- /all: filtra exclusivamente APPROVED.
- Devocionales, búsqueda de pastor y broadcasts push: reemplazan active: true por status: APPROVED.

### Infraestructura
- Agregar índice idx_members_church_status_created en MemberMongoRepository.

### Snapshots históricos (OnlineContributions)
- Separar hidratación histórica de agregado Member.
- Introducir ContributionMemberSnapshot con campos históricos necesarios.
- fromPrimitives() no usa Member.fromPrimitives(); toPrimitives() nunca expone active.

### Migración MongoDB
- Migración migrate-mongo idempotente en /migrations.
- active === false → INACTIVE; cualquier otro caso → APPROVED.
- Elimina active de todos los documentos y crea el índice nuevo.
- down como rollback técnico inmediato documentado.

### OpenAPI
- Actualizar docs/openapi/church-members.yaml: eliminar active, agregar status.
- Documentar diferencia entre /list (administrativo) y /all (operacional).

### Tests
- Actualizar CreateMember.spec.ts y UpdateMember.spec.ts para status.
- Verificar que sin status produce APPROVED; INACTIVE funciona; queue se dispara.

## Fuera de alcance
- No se implementa QR, links públicos, autoregistro, endpoints approve/reject, pantalla de pendientes, foto, dirección, sexo/género, LGPD, campañas ni estadísticas.
- El código Flutter no se encuentra en este repositorio; deberá sincronizarse en el repo correspondiente.

## Verificación
- bun test: tests de CreateMember y UpdateMember pasan.
- búsqueda manual de active en src: únicos usos restantes pertenecen a bancos, conceptos financieros, cost centers y support assistant (no Member).