### PR TITLE
config(public-link): ajusta config y docs para enlace público en app.gloriafinance.com.br

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,9 @@ SEND_MAIL_SERVICE_CLIENT_EMAIL=
 SEND_MAIL_USER=
 SEND_MAIL_PRIVATE_KEY=
 
+# URL pública de la aplicación web (usada para construir links absolutos en emails y notificaciones)
+WEBAPP_URL=https://app.gloriafinance.com.br
+
 MICROSOFT_TENANT_ID=
 MICROSOFT_CLIENT_ID=
 

--- a/docs/openapi/church-members.yaml
+++ b/docs/openapi/church-members.yaml
@@ -125,7 +125,7 @@ paths:
   /api/v1/church/member/registration-link:
     get:
       summary: Obtém ou cria o link de autoregistro de membros
-      description: Retorna o token persistido da igreja e o caminho público relativo. Se o token ainda não existir, gera uma única vez.
+      description: Retorna o token persistido da igreja e o caminho público relativo (`registrationPath`). O caminho deve ser resolvido contra o domínio público da aplicação (`https://app.gloriafinance.com.br`) para formar o link absoluto de autoregistro. Se o token ainda não existir, gera uma única vez.
       tags: [ Church Members ]
       responses:
         '200':


### PR DESCRIPTION
## Cambios

- Agrega `WEBAPP_URL` a `.env.example` apuntando a `https://app.gloriafinance.com.br`.
- Actualiza la descripción del endpoint `GET /api/v1/church/member/registration-link` en OpenAPI para dejar explícito que `registrationPath` es relativo al dominio público de la app.

## Contexto
Este PR forma parte del ajuste del enlace público de registro de miembros al subdominio `app.gloriafinance.com.br`. El backend continúa publicando el path relativo como contrato; la URL absoluta es responsabilidad del frontend.