### PR TITLE
chore(members): migrate birthdate/conversionDate/baptismDate from dd/mm/yyyy strings to BSON Date

### DIFF
--- a/migrations/20260602090000-normalize-member-date-strings.js
+++ b/migrations/20260602090000-normalize-member-date-strings.js
@@ -1,0 +1,237 @@
+const FIELDS = ["birthdate", "conversionDate", "baptismDate"]
+
+const DDMMYYYY = /^(\d{2})\/(\d{2})\/(\d{4})$/
+const YYYYMMDD = /^(\d{4})-(\d{2})-(\d{2})$/
+
+function toUtcMidnight(y, m, d) {
+  return new Date(Date.UTC(y, m - 1, d))
+}
+
+function isValidCalendarDate(y, m, d) {
+  const dt = new Date(Date.UTC(y, m - 1, d))
+  return (
+    dt.getUTCFullYear() === y &&
+    dt.getUTCMonth() === m - 1 &&
+    dt.getUTCDate() === d
+  )
+}
+
+function parseLegacy(raw) {
+  if (raw instanceof Date) {
+    return { action: "skip", reason: "already-Date" }
+  }
+  if (raw === null || raw === undefined) {
+    return { action: "skip", reason: "null" }
+  }
+  if (typeof raw !== "string") {
+    return { action: "skip", reason: "non-string-non-date" }
+  }
+
+  const s = raw.trim()
+  if (!s) {
+    return { action: "skip", reason: "empty" }
+  }
+
+  let m = s.match(DDMMYYYY)
+  if (m) {
+    const dd = Number(m[1])
+    const mm = Number(m[2])
+    const yyyy = Number(m[3])
+    if (!isValidCalendarDate(yyyy, mm, dd)) {
+      return { action: "skip", reason: "invalid-dmy-date" }
+    }
+    return { action: "convert", date: toUtcMidnight(yyyy, mm, dd) }
+  }
+
+  m = s.match(YYYYMMDD)
+  if (m) {
+    const yyyy = Number(m[1])
+    const mm = Number(m[2])
+    const dd = Number(m[3])
+    if (!isValidCalendarDate(yyyy, mm, dd)) {
+      return { action: "skip", reason: "invalid-ymd-date" }
+    }
+    return { action: "convert", date: toUtcMidnight(yyyy, mm, dd) }
+  }
+
+  return { action: "skip", reason: "unrecognized-format" }
+}
+
+function pad2(n) {
+  return n < 10 ? `0${n}` : String(n)
+}
+
+function dateToDdMmYyyy(date) {
+  const dd = pad2(date.getUTCDate())
+  const mm = pad2(date.getUTCMonth() + 1)
+  const yyyy = date.getUTCFullYear()
+  return `${dd}/${mm}/${yyyy}`
+}
+
+module.exports = {
+  /**
+   * @param db {import('mongodb').Db}
+   * @param client {import('mongodb').MongoClient}
+   * @returns {Promise<void>}
+   */
+  async up(db, client) {
+    const collection = db.collection("members")
+
+    const summary = {
+      fields: FIELDS,
+      converted: Object.fromEntries(FIELDS.map((f) => [f, 0])),
+      skipped: Object.fromEntries(FIELDS.map((f) => [f, 0])),
+      skippedDetails: [],
+    }
+
+    const cursor = collection.find(
+      {},
+      {
+        projection: {
+          _id: 1,
+          memberId: 1,
+          birthdate: 1,
+          conversionDate: 1,
+          baptismDate: 1,
+        },
+      }
+    )
+
+    let batch = []
+    const BATCH_SIZE = 500
+
+    while (await cursor.hasNext()) {
+      const doc = await cursor.next()
+      if (!doc) continue
+
+      const setOps = {}
+
+      for (const field of FIELDS) {
+        const result = parseLegacy(doc[field])
+
+        if (result.action === "convert") {
+          setOps[field] = result.date
+          summary.converted[field] += 1
+        } else {
+          summary.skipped[field] += 1
+          if (result.reason !== "already-Date" && result.reason !== "null") {
+            summary.skippedDetails.push({
+              memberId: doc.memberId ?? String(doc._id),
+              field,
+              raw: doc[field],
+              reason: result.reason,
+            })
+          }
+        }
+      }
+
+      if (Object.keys(setOps).length > 0) {
+        batch.push({
+          updateOne: {
+            filter: { _id: doc._id },
+            update: { $set: setOps },
+          },
+        })
+      }
+
+      if (batch.length >= BATCH_SIZE) {
+        await collection.bulkWrite(batch, { ordered: false })
+        batch = []
+      }
+    }
+
+    if (batch.length > 0) {
+      await collection.bulkWrite(batch, { ordered: false })
+    }
+
+    await cursor.close()
+
+    // eslint-disable-next-line no-console
+    console.log("[normalize-member-date-strings] up summary:")
+    // eslint-disable-next-line no-console
+    console.log(JSON.stringify(summary, null, 2))
+  },
+
+  /**
+   * @param db {import('mongodb').Db}
+   * @param client {import('mongodb').MongoClient}
+   * @returns {Promise<void>}
+   */
+  async down(db, client) {
+    const collection = db.collection("members")
+
+    const summary = {
+      fields: FIELDS,
+      converted: Object.fromEntries(FIELDS.map((f) => [f, 0])),
+      skipped: Object.fromEntries(FIELDS.map((f) => [f, 0])),
+      skippedDetails: [],
+    }
+
+    const cursor = collection.find(
+      {},
+      {
+        projection: {
+          _id: 1,
+          memberId: 1,
+          birthdate: 1,
+          conversionDate: 1,
+          baptismDate: 1,
+        },
+      }
+    )
+
+    let batch = []
+    const BATCH_SIZE = 500
+
+    while (await cursor.hasNext()) {
+      const doc = await cursor.next()
+      if (!doc) continue
+
+      const setOps = {}
+
+      for (const field of FIELDS) {
+        const value = doc[field]
+
+        if (value instanceof Date) {
+          setOps[field] = dateToDdMmYyyy(value)
+          summary.converted[field] += 1
+        } else {
+          summary.skipped[field] += 1
+          if (value !== null && value !== undefined) {
+            summary.skippedDetails.push({
+              memberId: doc.memberId ?? String(doc._id),
+              field,
+              raw: value,
+              reason: "not-a-date",
+            })
+          }
+        }
+      }
+
+      if (Object.keys(setOps).length > 0) {
+        batch.push({
+          updateOne: {
+            filter: { _id: doc._id },
+            update: { $set: setOps },
+          },
+        })
+      }
+
+      if (batch.length >= BATCH_SIZE) {
+        await collection.bulkWrite(batch, { ordered: false })
+        batch = []
+      }
+    }
+
+    if (batch.length > 0) {
+      await collection.bulkWrite(batch, { ordered: false })
+    }
+
+    await cursor.close()
+
+    // eslint-disable-next-line no-console
+    console.log("[normalize-member-date-strings] down summary:")
+    // eslint-disable-next-line no-console
+    console.log(JSON.stringify(summary, null, 2))
+  },
+}


### PR DESCRIPTION
## Resumen

Normaliza los campos `birthdate`, `conversionDate` y `baptismDate` de la colección `members` que estaban almacenados como **strings en formato `dd/mm/yyyy`** a **objetos BSON `Date`** (medianoche UTC del mismo día calendario). La capa de dominio (`Member.ts`) ya tipa estos campos como `Date`, por lo que valores-string rompen la asignación en `Member.fromPrimitives` y cualquier query por rango.

## Cambios

### Nuevo archivo
- `migrations/20260602090000-normalize-member-date-strings.js`

### Comportamiento de `up`
- Convierte strings válidos en formato `dd/mm/yyyy` o `YYYY-MM-DD` a `new Date(Date.UTC(yyyy, mm-1, dd))`.
- Valida el día calendario (rechaza por ejemplo `31/02/2020`, acepta `29/02/2020`).
- Deja intactos los valores que ya son BSON `Date`, `null` o están ausentes.
- **Skip + log** de cualquier valor no reconocible (texto basura, string vacío, número, etc.) con `memberId`, `field`, valor crudo y razón. **No** hace `$unset`, **no** modifica esos campos.
- Imprime al final un resumen JSON con `converted`/`skipped` por campo y `skippedDetails` con la lista de valores no convertidos para revisión manual.
- Procesa en lotes de 500 con `bulkWrite` (`ordered: false`).
- **Idempotente**: re-ejecutar no convierte nada (cuenta convertidos = 0).

### Comportamiento de `down`
- Invierte la conversión: cada `Date` se reescribe a su cadena `dd/mm/yyyy` usando componentes UTC, lo cual es la inversa exacta de `up` para fechas calendario.
- Los valores no-Date se omiten (no se pierden ni se modifican).

## Verificación local
Pruebas ejecutadas contra una base de datos Mongo local con 8 documentos sintéticos que cubren:
- `dd/mm/yyyy` válido (m1, m5, m7)
- `YYYY-MM-DD` válido (m2, mixto)
- ya `Date` (m3)
- día calendario inválido `31/02/2020` (m4) → skip
- año bisiesto válido `29/02/2020` (m6) → convierte
- `null` (m5 birthdate) → skip silencioso
- string vacío (m4 baptismDate) → skip + log
- número `1234567890` (m8 birthdate) → skip + log
- texto basura `garbage` (m4 conversionDate) → skip + log

Resultados:
- `up` convirtió 4 + 5 + 2 valores en la primera ejecución.
- Re-ejecutar `up`: 0 conversiones, 8 skips por campo.
- `down` revirtió 5 + 6 + 2 valores a string `dd/mm/yyyy`.

`node --check` y `prettier --check` pasan.

## Runbook

Antes de aplicar en producción:
```bash
bash scripts/backup-mongo.sh
```

Aplicar:
```bash
npm run migrate
```

Verificar:
```js
// mongosh
db.members.aggregate([
  { $project: { not_date: { $ne: [{ $type: "$birthdate" }, "date"] } } },
  { $match: { not_date: true } },
  { $count: "leftover" }
])
// esperado: leftover: 0
```

Para los valores en `skippedDetails` (que aparecerán en la salida del script) revisar manualmente si deben corregirse o dejarse como nulos.

## Lo que **no** cambia
- Código de aplicación (Member domain, controller, validators).
- Endpoint público de auto-registro que hace `new Date(body.birthdate)` — por política de **strict contracts** (`AGENTS.md`), no se agregan normalizaciones silenciosas entre capas. Ese bug de contrato (un input `dd/mm/yyyy` produce `Invalid Date`) es un ticket separado que debe negociar el formato con el frontend.
- Otros campos de `members` u otras colecciones.

## Criterios de aceptación
- [x] Convierte `dd/mm/yyyy` y `YYYY-MM-DD` a BSON `Date` UTC midnight.
- [x] Conserva los valores ya `Date`, `null` o ausentes.
- [x] No convierte valores no reconocibles; los lista en el log.
- [x] Idempotente (re-ejecutable sin efectos).
- [x] `down` revierte la conversión.
- [x] Sin cambios en código de aplicación.